### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -4,6 +4,8 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/stephenlyons18/stephenlyons18.github.io/security/code-scanning/1](https://github.com/stephenlyons18/stephenlyons18.github.io/security/code-scanning/1)

To fix the problem, add a `permissions` block either at the root of the workflow or specifically under the `jobs.test` entry in .github/workflows/trufflehog.yaml. The minimal necessary permissions for this workflow are `contents: read`, which allows the job to check out code but prevents it from making changes to the repository or other resources. Add the following block at the appropriate location:

At the root level, immediately after `on: ...` and before `jobs:`:
```yaml
permissions:
  contents: read
```
This will apply least privilege restrictions to the entire workflow. If you want future flexibility for other jobs, you can add this block at the job level, but for this file, root level is simpler and recommended.

No new methods, packages, or definitions are required; this is a purely configuration change within the YAML workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
