### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,10 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Default token scope for all jobs unless overridden at job level.
+permissions:
+  contents: read
+
 jobs:
   # ─────────────────────────────────────────────────────────────
   # JOB 1 — Build


### PR DESCRIPTION
Potential fix for [https://github.com/stephenlyons18/stephenlyons18.github.io/security/code-scanning/1](https://github.com/stephenlyons18/stephenlyons18.github.io/security/code-scanning/1)

Add explicit `permissions` for the workflow so all jobs are least-privilege by default, while preserving existing functionality by keeping `deploy`’s explicit write permission.

Best single fix here:
- In `.github/workflows/deploy.yml`, add a root-level permissions block (after `env` and before `jobs`) with:
  - `contents: read`
- Keep the existing `deploy` job `permissions: contents: write` unchanged, so deploy can still push to `build` branch.
- This gives `build` read-only token (sufficient for checkout/artifact flow) and keeps deploy behavior intact.

No imports, methods, or dependencies are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
